### PR TITLE
Feature/device orientation

### DIFF
--- a/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
+++ b/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
@@ -37,7 +37,7 @@ const DeviceOrientationSample = () => {
     }) => {
       // 初期化
       g.clear();
-      // lineStyle(線の太さ, 色)
+      // 線の太さ, 色
       g.lineStyle(1, 0xff0000);
       // 横線
       g.moveTo(-16, 0);
@@ -60,6 +60,7 @@ const DeviceOrientationSample = () => {
       endFill: () => void;
     }) => {
       g.clear();
+      // 線の太さ, 色
       g.lineStyle(1, 0xff0000);
       // 横線
       g.moveTo(-40, 0);

--- a/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
+++ b/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
@@ -123,55 +123,63 @@ const DeviceOrientationSample = () => {
 
       <hr />
 
-      {/* ReactPixi で描画 (x, y 確認用) */}
-      <Stage width={240} height={240} options={{ background: 0x1099bb }}>
-        {/* メインのコンテナ */}
-        <Container anchor={0.5} position={[120, 120]}>
-          {/* <Text text="Hello World!" anchor={0.5} /> */}
-          {/* もだね */}
-          <Sprite image={bunnyUrl} anchor={0.5} x={gamma ?? 0} y={beta ?? 0} />
-          {/* 十字線 */}
-          <Graphics draw={Crosshair} />
-        </Container>
+      {/* ReactPixi の描画サンプル */}
+      <div className="flex flex-col gap-8">
+        {/* ReactPixi で描画 (x, y 確認用) */}
+        <Stage width={240} height={240} options={{ background: 0x1099bb }}>
+          {/* メインのコンテナ */}
+          <Container anchor={0.5} position={[120, 120]}>
+            {/* <Text text="Hello World!" anchor={0.5} /> */}
+            {/* もだね */}
+            <Sprite
+              image={bunnyUrl}
+              anchor={0.5}
+              x={gamma ?? 0}
+              y={beta ?? 0}
+            />
+            {/* 十字線 */}
+            <Graphics draw={Crosshair} />
+          </Container>
 
-        {/* 傾き情報のコンテナ */}
-        <Container position={[5, 5]}>
-          <Text
-            text={`x (gamma): ${gamma}`}
-            style={new TextStyle(infoTextStyle)}
-          />
-          <Text
-            text={`y (beta): ${beta}`}
-            y={16}
-            style={new TextStyle(infoTextStyle)}
-          />
-        </Container>
-      </Stage>
+          {/* 傾き情報のコンテナ */}
+          <Container position={[5, 5]}>
+            <Text
+              text={`x (gamma): ${gamma}`}
+              style={new TextStyle(infoTextStyle)}
+            />
+            <Text
+              text={`y (beta): ${beta}`}
+              y={16}
+              style={new TextStyle(infoTextStyle)}
+            />
+          </Container>
+        </Stage>
 
-      <hr />
+        {/* ReactPixi で描画 (rotation 確認用) */}
+        <Stage width={240} height={240} options={{ background: 0x1099bb }}>
+          {/* メインのコンテナ */}
+          <Container anchor={0.5} position={[120, 120]}>
+            {/* <Text text="Hello World!" anchor={0.5} /> */}
+            {/* もだね */}
+            <Sprite image={bunnyUrl} anchor={0.5} rotation={rad} />
+            {/* 円 */}
+            <Graphics draw={Circle} />
+          </Container>
 
-      {/* ReactPixi で描画 (rotation 確認用) */}
-      <Stage width={240} height={240} options={{ background: 0x1099bb }}>
-        {/* メインのコンテナ */}
-        <Container anchor={0.5} position={[120, 120]}>
-          {/* <Text text="Hello World!" anchor={0.5} /> */}
-          {/* もだね */}
-          <Sprite image={bunnyUrl} anchor={0.5} rotation={rad} />
-          {/* 円 */}
-          <Graphics draw={Circle} />
-        </Container>
-
-        {/* 傾き情報のコンテナ */}
-        <Container position={[5, 5]}>
-          <Text text={`alpha:${alpha}`} style={new TextStyle(infoTextStyle)} />
-          <Text
-            text={`radian ((alpha * π) / 180):${rad}`}
-            y={16}
-            style={new TextStyle(infoTextStyle)}
-          />
-        </Container>
-      </Stage>
-
+          {/* 傾き情報のコンテナ */}
+          <Container position={[5, 5]}>
+            <Text
+              text={`alpha:${alpha}`}
+              style={new TextStyle(infoTextStyle)}
+            />
+            <Text
+              text={`radian ((alpha * π) / 180):${rad}`}
+              y={16}
+              style={new TextStyle(infoTextStyle)}
+            />
+          </Container>
+        </Stage>
+      </div>
       <hr />
     </div>
   );

--- a/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
+++ b/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
@@ -100,12 +100,7 @@ const DeviceOrientationSample = () => {
         <Container anchor={0.5} position={[120, 120]}>
           {/* <Text text="Hello World!" anchor={0.5} /> */}
           {/* もだね */}
-          <Sprite
-            image={bunnyUrl}
-            anchor={0.5}
-            x={gamma ?? undefined}
-            y={beta ?? undefined}
-          />
+          <Sprite image={bunnyUrl} anchor={0.5} x={gamma ?? 0} y={beta ?? 0} />
           {/* 十字線 */}
           <Graphics draw={Crosshair} />
         </Container>

--- a/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
+++ b/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
@@ -92,7 +92,7 @@ const DeviceOrientationSample = () => {
           <progress className="progress" value={alpha ?? 0} max="360" />
           <div className="flex items-center gap-2">
             <RotateCcw strokeWidth={1} />
-            alpha: {alpha}
+            alpha: {alpha ?? "端末方向イベントを読み取れませんでした"}
           </div>
         </div>
         <div>
@@ -104,7 +104,7 @@ const DeviceOrientationSample = () => {
           />
           <div className="flex items-center gap-2">
             <MoveVertical strokeWidth={1} />
-            beta: {beta}
+            beta: {beta ?? "端末方向イベントを読み取れませんでした"}
           </div>
         </div>
         <div>
@@ -116,7 +116,7 @@ const DeviceOrientationSample = () => {
           />
           <div className="flex items-center gap-2">
             <MoveHorizontal strokeWidth={1} />
-            gamma: {gamma}
+            gamma: {gamma ?? "端末方向イベントを読み取れませんでした"}
           </div>
         </div>
       </div>

--- a/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
+++ b/src/app/(toys)/device-orientation/_components/device-orientation-sample.tsx
@@ -4,6 +4,7 @@ import { useDeviceOrientation } from "@/hooks/use-device-orientation";
 import { requestDeviceMotionPermission } from "@/utilities/request-device-motion-permission";
 import { Container, Graphics, Sprite, Stage, Text } from "@pixi/react";
 import { TextStyle } from "@pixi/text";
+import { MoveHorizontal, MoveVertical, RotateCcw } from "lucide-react";
 import { useCallback } from "react";
 
 const DeviceOrientationSample = () => {
@@ -86,11 +87,39 @@ const DeviceOrientationSample = () => {
       <hr />
 
       {/* 取得した情報のリストアップ */}
-      <ul>
-        <li>alpha: {alpha}</li>
-        <li>beta: {beta}</li>
-        <li>gamma: {gamma}</li>
-      </ul>
+      <div className="flex flex-col gap-4">
+        <div>
+          <progress className="progress" value={alpha ?? 0} max="360" />
+          <div className="flex items-center gap-2">
+            <RotateCcw strokeWidth={1} />
+            alpha: {alpha}
+          </div>
+        </div>
+        <div>
+          <progress
+            className="progress "
+            // daisyUI の progress は最小値に対応していないため 値 + 180 & 最大値 360 とする
+            value={beta ? beta + 180 : 0}
+            max="360"
+          />
+          <div className="flex items-center gap-2">
+            <MoveVertical strokeWidth={1} />
+            beta: {beta}
+          </div>
+        </div>
+        <div>
+          <progress
+            className="progress "
+            // daisyUI の progress は最小値に対応していないため 値 + 90 & 最大値 180 とする
+            value={gamma ? gamma + 90 : 0}
+            max="180"
+          />
+          <div className="flex items-center gap-2">
+            <MoveHorizontal strokeWidth={1} />
+            gamma: {gamma}
+          </div>
+        </div>
+      </div>
 
       <hr />
 

--- a/src/app/(toys)/device-orientation/page.mdx
+++ b/src/app/(toys)/device-orientation/page.mdx
@@ -75,4 +75,4 @@ import { Version } from "@/components/atoms/version";
 - [PixiJS + React で実装する時のメモ](https://zenn.dev/ivgtr/scraps/f3c1a7ae0e3e5b)
 - [ラジアン｜単位プラス｜大日本図書](https://www.dainippon-tosho.co.jp/unit/list/radian.html)
 
-<Version version="0.2.0" onDate="2025-07-30" />
+<Version version="0.2.1" onDate="2025-10-27" />

--- a/src/app/(toys)/device-orientation/page.mdx
+++ b/src/app/(toys)/device-orientation/page.mdx
@@ -3,7 +3,7 @@ import { Version } from "@/components/atoms/version";
 
 # 傾き検知サンプル集
 
-デバイスの [端末方向イベント](https://developer.mozilla.org/ja/docs/Web/API/Device_orientation_events) を取得し、[ReactPixi](https://pixijs.io/pixi-react/) で描画するサンプルです。
+デバイスの [端末方向イベント](https://developer.mozilla.org/ja/docs/Web/API/Device_orientation_events) を取得し、[ReactPixi](https://pixijs.io/pixi-react/) などで描画するサンプルです。
 
 スマートフォンなど、傾き検知が利用できるデバイスでご利用ください。
 


### PR DESCRIPTION
This pull request updates the device orientation sample UI to provide a more intuitive and visually informative display of device orientation data. The changes include replacing the simple list of orientation values with progress bars and icons, improving user feedback, and making minor UI and code adjustments for clarity and robustness.

**UI/UX Improvements:**

* The display of `alpha`, `beta`, and `gamma` orientation values has been changed from a plain list to progress bars with descriptive icons, offering a clearer and more interactive visualization.
* Added fallback messages for cases when device orientation events cannot be read, improving user feedback.

**Code and Rendering Adjustments:**

* The `Sprite` component in the ReactPixi sample now defaults `x` and `y` to 0 if `gamma` or `beta` are unavailable, preventing rendering issues.
* Minor code formatting and container adjustments were made to better group and separate UI sections, enhancing readability and maintainability. [[1]](diffhunk://#diff-868d024bd168cba1e262e8dd89d4347582f35ebe77ed757d6645b4cef5a1050bL127-L128) [[2]](diffhunk://#diff-868d024bd168cba1e262e8dd89d4347582f35ebe77ed757d6645b4cef5a1050bL142-R182)

**Documentation Update:**

* The documentation in `page.mdx` was updated to note that the sample now uses ReactPixi "など" (and others), reflecting the broader range of rendering techniques.