### PR TITLE
fix: update icon reference from Heroicons to Lucide in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 npm run dev
 ```
 
-## Reference
+## References
 
 ### Next.js
 
@@ -60,7 +60,7 @@ npm run dev
 
 ### Icons
 
-- [Heroicons](https://heroicons.com/)
+- [Lucide](https://lucide.dev/)
 
 ### ESLint
 

--- a/src/app/(toys)/about/page.mdx
+++ b/src/app/(toys)/about/page.mdx
@@ -46,7 +46,7 @@
 
 ### アイコン
 
-- [Heroicons](https://heroicons.com/)
+- [Lucide](https://lucide.dev/)
 
 ### ホスティング
 


### PR DESCRIPTION
This pull request updates documentation to reflect a change in the icon library used in the project, switching references from Heroicons to Lucide in both the English and Japanese documentation. Additionally, it corrects a section header in the English README.

Documentation updates:

* Updated the icon library reference from "Heroicons" to "Lucide" in both the English `README.md` and the Japanese `about/page.mdx` documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R63) [[2]](diffhunk://#diff-0e90cf423c8bbf3e1253e84516cf3cb2e6f9a8cc498ad23937a15a6225f4a759L49-R49)
* Fixed the section header from "Reference" to "References" in `README.md`.