### PR TITLE
feat: add DateOnClientSide and DateOnServerSide components for displa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@react-three/postprocessing": "^2.16.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "emoji-mart": "^5.6.0",
         "emoji-regex": "^10.3.0",
         "js-confetti": "^0.12.0",
@@ -5206,6 +5207,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-three/postprocessing": "^2.16.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "emoji-mart": "^5.6.0",
     "emoji-regex": "^10.3.0",
     "js-confetti": "^0.12.0",

--- a/src/app/(toys)/hello-world/date/_components/date-on-client-side.tsx
+++ b/src/app/(toys)/hello-world/date/_components/date-on-client-side.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { format } from "date-fns";
+
+function DateOnClientSide() {
+  return <div>{format(new Date(), "yyyy-MM-dd HH:mm:ss")}</div>;
+}
+
+export { DateOnClientSide };

--- a/src/app/(toys)/hello-world/date/_components/date-on-server-side.tsx
+++ b/src/app/(toys)/hello-world/date/_components/date-on-server-side.tsx
@@ -1,0 +1,7 @@
+import { format } from "date-fns";
+
+function DateOnServerSide() {
+  return <div>{format(new Date(), "yyyy-MM-dd HH:mm:ss")}</div>;
+}
+
+export { DateOnServerSide };

--- a/src/app/(toys)/hello-world/date/page.tsx
+++ b/src/app/(toys)/hello-world/date/page.tsx
@@ -1,0 +1,17 @@
+import { DateOnClientSide } from "./_components/date-on-client-side";
+import { DateOnServerSide } from "./_components/date-on-server-side";
+
+function DatePage() {
+  return (
+    <>
+      <h1>Date</h1>
+
+      <div className="flex flex-col gap-4">
+        <DateOnClientSide />
+        <DateOnServerSide />
+      </div>
+    </>
+  );
+}
+
+export default DatePage;

--- a/src/app/(toys)/hello-world/page.mdx
+++ b/src/app/(toys)/hello-world/page.mdx
@@ -13,6 +13,6 @@ import Link from "next/link";
 - <Link href="/hello-world/react-hooks/">React Hooks</Link>
 - <Link href="/hello-world/react-hook-form/">React Hook Form</Link>
 
-## Backup
+## Date
 
-- <Link href="/hello-world/toy-layout/">ToyLayout</Link>
+- <Link href="/hello-world/date/">Date</Link>


### PR DESCRIPTION
This pull request introduces a new "Date" page to the Hello World toys section, showcasing both client-side and server-side date rendering. It adds two new components for displaying the current date and updates the navigation to include the new page.

**New Date Page and Components:**

* Added `DatePage` in `page.tsx`, which displays the current date using both client-side and server-side rendered components.
* Implemented `DateOnClientSide` (`date-on-client-side.tsx`) to render the current date/time on the client using `date-fns`.
* Implemented `DateOnServerSide` (`date-on-server-side.tsx`) to render the current date/time on the server using `date-fns`.

**Navigation Update:**

* Updated the Hello World navigation in `page.mdx` to include a link to the new "Date" page.…ying current date