### PR TITLE
Feature/fix breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7326,9 +7326,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
-      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.14.tgz",
+      "integrity": "sha512-CSpT2aXsv71HST8C5ETeVo+6YybqCpHBiYrCRQSn3U5QUZuLTSsvtq/bj+zuvjLVADeKxoebzo16OkH8m1+65Q==",
       "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
@@ -10462,9 +10462,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
-      "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
+      "version": "7.66.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
+      "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/src/components/shared/breadcrumbs.tsx
+++ b/src/components/shared/breadcrumbs.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSelectedLayoutSegments } from "next/navigation";
+import React from "react";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -22,17 +23,15 @@ function Breadcrumbs() {
   return (
     <Breadcrumb>
       <BreadcrumbList>
-        {/* ホームへのリンクは静的に作成する */}
         <BreadcrumbItem>
           <BreadcrumbLink asChild>
             <Link href="/">Home</Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        {/* セグメントを map で繰り返し生成 */}
         {pathnamesIgnoredRouteGroups.map((segment, index) => (
-          <>
+          <React.Fragment key={segment}>
             <BreadcrumbSeparator />
-            <BreadcrumbItem key={segment}>
+            <BreadcrumbItem>
               {/**
                * 最後のセグメント以外はリンクとして表示する
                * 最後のセグメントはテキストとして表示する
@@ -42,14 +41,16 @@ function Breadcrumbs() {
               ) : (
                 <BreadcrumbLink asChild>
                   <Link
-                    href={`/${pathnamesIgnoredRouteGroups.slice(0, index + 1).join("/")}`}
+                    href={`/${pathnamesIgnoredRouteGroups
+                      .slice(0, index + 1)
+                      .join("/")}`}
                   >
                     {segment}
                   </Link>
                 </BreadcrumbLink>
               )}
             </BreadcrumbItem>
-          </>
+          </React.Fragment>
         ))}
       </BreadcrumbList>
     </Breadcrumb>


### PR DESCRIPTION
This pull request makes minor improvements to the `Breadcrumbs` component, focusing on React best practices and code clarity.

Component improvements:

* Replaced the use of `<>...</>` fragments with `React.Fragment` and added a unique `key` prop to each fragment in the breadcrumbs mapping for better React list rendering practices.
* Added the `React` import to support the use of `React.Fragment`.

Code formatting:

* Reformatted the `href` construction in the breadcrumb link for improved readability.