### PR TITLE
Feature/change color theme

### DIFF
--- a/src/app/(toys)/hello-world/colors/_components/colors.tsx
+++ b/src/app/(toys)/hello-world/colors/_components/colors.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+import { HTMLAttributes, ReactNode } from "react";
+
+type ColorProps = {
+  children: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+function Color({ children, className }: ColorProps) {
+  return (
+    <div
+      className={cn(
+        `flex h-12 w-40 items-center justify-center text-sm`,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Colors() {
+  return (
+    <div className="flex flex-wrap">
+      <Color className="bg-primary text-primary-foreground">primary</Color>
+    </div>
+  );
+}

--- a/src/app/(toys)/hello-world/colors/_components/colors.tsx
+++ b/src/app/(toys)/hello-world/colors/_components/colors.tsx
@@ -48,6 +48,7 @@ export function Colors() {
         <Color className="bg-background text-foreground">background</Color>
         <Color className="bg-card text-card-foreground">card</Color>
         <Color className="bg-popover text-popover-foreground">popover</Color>
+        <Color className="bg-primary text-primary-foreground">primary</Color>
         <Color className="bg-secondary text-secondary-foreground">
           secondary
         </Color>
@@ -93,6 +94,13 @@ export function Colors() {
         </Color>
         <Color className="bg-sidebar-border">sidebar-border</Color>
         <Color className="bg-sidebar-ring text-white">sidebar-ring</Color>
+      </ColorBackground>
+
+      <h2>Other colors</h2>
+      <p>Shows other colors.</p>
+
+      <ColorBackground>
+        <Color className="bg-personal text-personal-foreground">personal</Color>
       </ColorBackground>
     </>
   );

--- a/src/app/(toys)/hello-world/colors/_components/colors.tsx
+++ b/src/app/(toys)/hello-world/colors/_components/colors.tsx
@@ -52,6 +52,7 @@ export function Colors() {
         <Color className="bg-secondary text-secondary-foreground">
           secondary
         </Color>
+        <Color className="bg-tertiary text-tertiary-foreground">tertiary</Color>
         <Color className="bg-muted text-muted-foreground">muted</Color>
         <Color className="bg-accent text-accent-foreground">accent</Color>
         <Color className="bg-destructive text-destructive-foreground">
@@ -101,6 +102,7 @@ export function Colors() {
 
       <ColorBackground>
         <Color className="bg-personal text-personal-foreground">personal</Color>
+        <Color className="bg-modane text-modane-foreground">modane</Color>
       </ColorBackground>
     </>
   );

--- a/src/app/(toys)/hello-world/colors/_components/colors.tsx
+++ b/src/app/(toys)/hello-world/colors/_components/colors.tsx
@@ -9,7 +9,24 @@ function Color({ children, className }: ColorProps) {
   return (
     <div
       className={cn(
-        `flex h-12 w-40 items-center justify-center text-sm`,
+        `flex h-10 items-center justify-center rounded text-sm`,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ColorBackgroundProps = {
+  children: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+function ColorBackground({ children, className }: ColorBackgroundProps) {
+  return (
+    <div
+      className={cn(
+        `grid grid-cols-2 gap-2 rounded-md bg-zinc-300 p-2 md:grid-cols-3`,
         className,
       )}
     >
@@ -20,8 +37,63 @@ function Color({ children, className }: ColorProps) {
 
 export function Colors() {
   return (
-    <div className="flex flex-wrap">
-      <Color className="bg-primary text-primary-foreground">primary</Color>
-    </div>
+    <>
+      <h2>Common UI Colors</h2>
+      <p>Shows common background and text color combinations.</p>
+
+      <pre>
+        {'<Color className="bg-background text-foreground">background</Color>'}
+      </pre>
+      <ColorBackground>
+        <Color className="bg-background text-foreground">background</Color>
+        <Color className="bg-card text-card-foreground">card</Color>
+        <Color className="bg-popover text-popover-foreground">popover</Color>
+        <Color className="bg-secondary text-secondary-foreground">
+          secondary
+        </Color>
+        <Color className="bg-muted text-muted-foreground">muted</Color>
+        <Color className="bg-accent text-accent-foreground">accent</Color>
+        <Color className="bg-destructive text-destructive-foreground">
+          destructive
+        </Color>
+      </ColorBackground>
+
+      <h2>Component colors</h2>
+      <p>Shows background color for components.</p>
+
+      <pre>{'<Color className="bg-border">border</Color>'}</pre>
+      <ColorBackground>
+        <Color className="bg-border">border</Color>
+        <Color className="bg-input">input</Color>
+        <Color className="bg-ring text-white">ring</Color>
+        <Color className="bg-chart-1">chart-1</Color>
+        <Color className="bg-chart-2">chart-2</Color>
+        <Color className="bg-chart-3 text-white">chart-3</Color>
+        <Color className="bg-chart-4">chart-4</Color>
+        <Color className="bg-chart-5">chart-5</Color>
+      </ColorBackground>
+
+      <h2>Sidebar colors</h2>
+      <p>Shows background colors for sidebar.</p>
+
+      <pre>
+        {
+          '<Color className="bg-sidebar text-sidebar-foreground">sidebar-background</Color>'
+        }
+      </pre>
+      <ColorBackground>
+        <Color className="bg-sidebar text-sidebar-foreground">
+          sidebar-background
+        </Color>
+        <Color className="bg-sidebar-primary text-sidebar-primary-foreground">
+          sidebar-primary
+        </Color>
+        <Color className="bg-sidebar-accent text-sidebar-accent-foreground">
+          sidebar-accent
+        </Color>
+        <Color className="bg-sidebar-border">sidebar-border</Color>
+        <Color className="bg-sidebar-ring text-white">sidebar-ring</Color>
+      </ColorBackground>
+    </>
   );
 }

--- a/src/app/(toys)/hello-world/colors/page.mdx
+++ b/src/app/(toys)/hello-world/colors/page.mdx
@@ -2,7 +2,7 @@ import { Colors } from "@/app/(toys)/hello-world/colors/_components/colors";
 
 # Colors
 
-KeM's Toys colors.
+KeM's Toys color palette.
 
 <Colors />
 

--- a/src/app/(toys)/hello-world/colors/page.mdx
+++ b/src/app/(toys)/hello-world/colors/page.mdx
@@ -1,0 +1,14 @@
+import { Colors } from "@/app/(toys)/hello-world/colors/_components/colors";
+
+# Colors
+
+KeM's Toys colors.
+
+<Colors />
+
+---
+
+## References
+
+- [Theme variables - Core concepts - Tailwind CSS](https://tailwindcss.com/docs/theme)
+- [Theming - shadcn/ui](https://ui.shadcn.com/docs/theming)

--- a/src/app/(toys)/hello-world/colors/page.mdx
+++ b/src/app/(toys)/hello-world/colors/page.mdx
@@ -10,5 +10,6 @@ KeM's Toys color palette.
 
 ## References
 
-- [Theme variables - Core concepts - Tailwind CSS](https://tailwindcss.com/docs/theme)
 - [Theming - shadcn/ui](https://ui.shadcn.com/docs/theming)
+- [Theme variables - Core concepts - Tailwind CSS](https://tailwindcss.com/docs/theme)
+- [HEX to HSL \| Html Colors](https://htmlcolors.com/hex-to-hsl)

--- a/src/app/(toys)/hello-world/page.mdx
+++ b/src/app/(toys)/hello-world/page.mdx
@@ -4,9 +4,10 @@ import Link from "next/link";
 
 スタイルの確認や各技術のテスト・練習用ページ。雑多です。
 
-## Markdown
+## Styling
 
 - <Link href="/hello-world/markdown/">Markdown</Link>
+- <Link href="/hello-world/colors/">Colors</Link>
 
 ## React
 

--- a/src/app/(toys)/hello-world/page.mdx
+++ b/src/app/(toys)/hello-world/page.mdx
@@ -4,6 +4,10 @@ import Link from "next/link";
 
 スタイルの確認や各技術のテスト・練習用ページ。雑多です。
 
+## Date
+
+- <Link href="/hello-world/date/">Date</Link>
+
 ## Styling
 
 - <Link href="/hello-world/markdown/">Markdown</Link>
@@ -14,6 +18,6 @@ import Link from "next/link";
 - <Link href="/hello-world/react-hooks/">React Hooks</Link>
 - <Link href="/hello-world/react-hook-form/">React Hook Form</Link>
 
-## Date
+## shadcn/ui
 
-- <Link href="/hello-world/date/">Date</Link>
+- <Link href="/hello-world/shadcn/">shadcn/ui</Link>

--- a/src/app/(toys)/hello-world/shadcn/page.tsx
+++ b/src/app/(toys)/hello-world/shadcn/page.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@/components/ui/button";
+
+export default function ShadcnPage() {
+  return (
+    <>
+      <h1>shadcn/ui</h1>
+      <div className="flex gap-4">
+        <div className="flex w-40 flex-col gap-4">
+          <Button>default</Button>
+          <Button variant="destructive">destructive</Button>
+          <Button variant="ghost">ghost</Button>
+          <Button variant="link">link</Button>
+          <Button variant="outline">outline</Button>
+          <Button variant="secondary">secondary</Button>
+        </div>
+
+        <div className="flex w-40 flex-col gap-4">
+          <Button size="sm">sm</Button>
+          <Button>default</Button>
+          <Button size="lg">lg</Button>
+
+          <div className="flex items-center gap-2">
+            <Button size="icon" />
+            <p>icon</p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: 210, 7%, 21%; /* #323539 */
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,8 @@
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
+    --tertiary: 188 43% 35%; /* 33757f */
+    --tertiary-foreground: 0 0% 98%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
@@ -39,6 +41,8 @@
     --sidebar-ring: 217.2 91.2% 59.8%;
     --personal: 188 42% 25%; /* #245259 */
     --personal-foreground: 0 0% 98%;
+    --modane: 0 100% 73%; /* ff7777 */
+    --modane-foreground: 0 0% 98%;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -51,6 +55,8 @@
     --primary-foreground: 0 0% 9%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
+    --tertiary: 188 43% 35%;
+    --tertiary-foreground: 0 0% 98%;
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;
     --accent: 0 0% 14.9%;
@@ -75,6 +81,8 @@
     --sidebar-ring: 217.2 91.2% 59.8%;
     --personal: 188 42% 25%; /* #245259 */
     --personal-foreground: 0 0% 98%;
+    --modane: 0 100% 73%; /* ff7777 */
+    --modane-foreground: 0 0% 98%;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 210, 7%, 21%; /* #323539 */
+    --primary: 210 7% 21%; /* #323539 */
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
@@ -37,6 +37,8 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --personal: 188 42% 25%; /* #245259 */
+    --personal-foreground: 0 0% 98%;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -71,6 +73,8 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --personal: 188 42% 25%; /* #245259 */
+    --personal-foreground: 0 0% 98%;
   }
 }
 

--- a/src/app/manifest.webmanifest
+++ b/src/app/manifest.webmanifest
@@ -2,8 +2,8 @@
   "name": "KeM's Toys",
   "display": "standalone",
   "start_url": "/",
-  "background_color": "#3f3f46",
-  "theme_color": "#3f3f46",
+  "background_color": "#323539",
+  "theme_color": "#323539",
   "shortcuts": [
     {
       "name": "おめでとうボタン",

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -9,7 +9,7 @@ export function AppHeader({ className, children, ...props }: AppHeaderProps) {
   return (
     <header
       className={cn(
-        "flex h-12 w-full items-center gap-2 bg-zinc-700 p-2 text-white",
+        "flex h-12 w-full items-center gap-2 bg-primary p-2 text-white",
         className,
       )}
       {...props}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -25,7 +25,7 @@ export function AppSidebar() {
           <Link href="/">
             <SidebarHeader
               className={`flex-row gap-2 rounded-md ${
-                pathname === "/" ? "bg-zinc-700 text-white" : ""
+                pathname === "/" ? "bg-primary text-white" : ""
               }`}
             >
               <Logo />
@@ -39,7 +39,7 @@ export function AppSidebar() {
                     isActive={pathname?.startsWith(toy.link)}
                     className={
                       pathname?.startsWith(toy.link)
-                        ? "hover:!bg-zinc-600 hover:!text-white data-[active=true]:bg-zinc-700 data-[active=true]:text-white"
+                        ? "hover:!text-white data-[active=true]:bg-primary data-[active=true]:text-white"
                         : ""
                     }
                     asChild

--- a/src/components/shared/version.tsx
+++ b/src/components/shared/version.tsx
@@ -6,10 +6,10 @@ interface VersionProps {
 function Version({ version, onDate }: VersionProps) {
   return (
     <div className="flex text-sm">
-      <span className="rounded-l-full bg-zinc-700 px-2 text-white">
+      <span className="rounded-l-full bg-primary px-2 text-white">
         v{version}
       </span>
-      <span className="rounded-r-full bg-zinc-200 px-2 text-zinc-700">
+      <span className="rounded-r-full bg-zinc-200 px-2 text-primary">
         on {onDate}
       </span>
     </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -292,7 +292,7 @@ const SidebarTrigger = React.forwardRef<
       variant="ghost"
       size="icon"
       className={cn(
-        "h-8 w-8 text-white hover:bg-zinc-600 hover:text-white",
+        "h-8 w-8 text-white hover:bg-primary hover:text-white",
         className,
       )}
       onClick={(event) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,6 +41,10 @@ const config: Config = {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
         },
+        tertiary: {
+          DEFAULT: "hsl(var(--tertiary))",
+          foreground: "hsl(var(--tertiary-foreground))",
+        },
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",
@@ -76,6 +80,10 @@ const config: Config = {
         personal: {
           DEFAULT: "hsl(var(--personal))",
           foreground: "hsl(var(--personal-foreground))",
+        },
+        modane: {
+          DEFAULT: "hsl(var(--modane))",
+          foreground: "hsl(var(--modane-foreground))",
         },
       },
       keyframes: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,6 +73,10 @@ const config: Config = {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
+        personal: {
+          DEFAULT: "hsl(var(--personal))",
+          foreground: "hsl(var(--personal-foreground))",
+        },
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
This pull request introduces a new color palette for the application, updates the global and sidebar styles to use the new colors, and adds demo pages for color and shadcn/ui component previews. The changes are grouped into three main themes: color palette enhancements, UI and style updates, and new demo pages.

**Color palette enhancements:**

* Added new color variables (`--tertiary`, `--personal`, `--modane` and their foregrounds) to `globals.css` for both light and dark themes, and updated the `--primary` color to a new shade (`#323539`). [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L13-R18) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R42-R45) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R58-R59) [[4]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R82-R85)
* Updated Tailwind CSS config to support the new color palette, including `tertiary`, `personal`, and `modane` color groups. [[1]](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R44-R47) [[2]](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R80-R87)

**UI and style updates:**

* Updated various components (`AppHeader`, `AppSidebar`, `Version`, `SidebarTrigger`) to use the new `primary` color instead of hardcoded `zinc` colors, ensuring consistency with the new palette. [[1]](diffhunk://#diff-4f00ff8b0dca2437cda2bbaf673b9a6bce3b8604fdd0ec53a81f00226d5a4e0cL12-R12) [[2]](diffhunk://#diff-c7a6b6877e86e67dbf604344adb85dee10e85fe8db08a831d08bd6a0ceedcfe5L28-R28) [[3]](diffhunk://#diff-c7a6b6877e86e67dbf604344adb85dee10e85fe8db08a831d08bd6a0ceedcfe5L42-R42) [[4]](diffhunk://#diff-fd0a8b3a70056b9479de04249855ca157a0e45d7ffde3c334e84853a91eba97aL9-R12) [[5]](diffhunk://#diff-dc267fc83481d6e45eb6d8382bcdc52460e7b211f270fbf46d24862014acaacaL295-R295)
* Changed the PWA manifest background and theme color to match the new primary color.

**New demo pages and components:**

* Added a new `Colors` component and a `/hello-world/colors/` MDX page to showcase the updated color palette and how to use the new color classes. [[1]](diffhunk://#diff-753c6138353d7726bc3b44642f55b229183d1b1a4f890f14ac9bd8b1442afc8bR1-R109) [[2]](diffhunk://#diff-bd3cfde5eaf9e4a862037a754e5053ec86a52b7db78d7a5f3630f7827d39a2dbR1-R15)
* Added a new `/hello-world/shadcn/` page to demonstrate various `shadcn/ui` button variants and sizes.
* Updated the `/hello-world/` index MDX page to include links to the new color and shadcn/ui demo pages.