### PR TITLE
fix: update hover background color for SidebarTrigger component

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -292,7 +292,7 @@ const SidebarTrigger = React.forwardRef<
       variant="ghost"
       size="icon"
       className={cn(
-        "h-8 w-8 text-white hover:bg-primary hover:text-white",
+        "h-8 w-8 text-white hover:bg-zinc-700 hover:text-white",
         className,
       )}
       onClick={(event) => {


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the sidebar trigger button. The button's hover background color has been changed from the primary theme color to a zinc gray shade, improving visual consistency with the rest of the interface.

- Changed the hover background color of the sidebar trigger button from `primary` to `zinc-700` in `sidebar.tsx` for better visual consistency.