### PR TITLE
Feature/update etrian calendar

### DIFF
--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -31,7 +31,6 @@ test.describe("世界樹の暦ページのテスト", () => {
         );
 
         // Act
-        await page.getByRole("link", { name: "icon KeM's Toys" }).click();
         await page
           .getByRole("link", { name: "世界樹の暦 今日は何ノ月？" })
           .click();

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -45,7 +45,6 @@ test.describe("世界樹の暦ページのテスト", () => {
         );
       });
     });
-
-    test.describe.skip("タスク作成時のテスト", () => {});
+    test.describe.skip("作成時のテスト", () => {});
   });
 });

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -20,7 +20,7 @@ test.describe("世界樹の暦ページのテスト", () => {
             },
             affiliations: ["ブレイバント", "アルカディア"],
             order: 0,
-            memo: "アルカディアの冒険者。没落貴族の一人娘。",
+            memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
           },
         ];
         await page.evaluate(
@@ -41,7 +41,7 @@ test.describe("世界樹の暦ページのテスト", () => {
         await expect(page.getByText("ブレイバント").first()).toBeVisible();
         await expect(page.getByText("アルカディア").first()).toBeVisible();
         await expect(
-          page.getByText("アルカディアの冒険者。没落貴族の一人娘。").first(),
+          page.getByText("突剣を自在に扱う冒険者。没落貴族の一人娘。").first(),
         ).toBeVisible();
 
         // Cleanup

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 test.describe("世界樹の暦ページのテスト", () => {
   test.describe("冒険者お誕生日台帳のテスト", () => {
     test.describe("初期表示のテスト", () => {
-      test("追加済みの冒険者「Added Task 1」が初期表示されること", async ({
+      test("追加済みの冒険者「セトハ」が初期表示されること", async ({
         page,
       }) => {
         // Arrange

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 test.describe("世界樹の暦ページのテスト", () => {
   test.describe("冒険者お誕生日台帳のテスト", () => {
     test.describe("初期表示のテスト", () => {
-      test("追加済みの冒険者「セトハ」が初期表示されること", async ({
+      test("追加済み冒険者の各種登録情報が初期表示されること", async ({
         page,
       }) => {
         // Arrange
@@ -37,6 +37,9 @@ test.describe("世界樹の暦ページのテスト", () => {
 
         // Assert
         await expect(page.getByText("セトハ").first()).toBeVisible();
+        await expect(page.getByText("皇帝ノ月 1 日").first()).toBeVisible();
+        await expect(page.getByText("ブレイバント").first()).toBeVisible();
+        await expect(page.getByText("アルカディア").first()).toBeVisible();
 
         // Cleanup
         await page.evaluate(

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -9,6 +9,7 @@ test.describe("世界樹の暦ページのテスト", () => {
         page,
       }) => {
         // Arrange
+        await page.goto("/");
         const etrians: Etrian[] = [
           {
             id: "test-etrian",
@@ -21,7 +22,6 @@ test.describe("世界樹の暦ページのテスト", () => {
             order: 0,
           },
         ];
-        await page.goto("/");
         await page.evaluate(
           ([key, value]) => {
             localStorage.setItem(key, value);

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -1,0 +1,51 @@
+import { Etrian } from "@/app/(toys)/etrian-calendar/_common/types/etrian";
+import { ETRIAN_REGISTRY_STORAGE_KEY } from "@/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry";
+import { expect, test } from "@playwright/test";
+
+test.describe("世界樹の暦ページのテスト", () => {
+  test.describe("冒険者お誕生日台帳のテスト", () => {
+    test.describe("初期表示のテスト", () => {
+      test("追加済みの冒険者「Added Task 1」が初期表示されること", async ({
+        page,
+      }) => {
+        // Arrange
+        const etrians: Etrian[] = [
+          {
+            id: "test-etrian",
+            name: "セトハ",
+            dateOfBirth: {
+              month: "皇帝ノ月",
+              day: 1,
+            },
+            affiliations: ["ブレイバント", "アルカディア"],
+            order: 0,
+          },
+        ];
+        await page.goto("/");
+        await page.evaluate(
+          ([key, value]) => {
+            localStorage.setItem(key, value);
+          },
+          [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
+        );
+
+        // Act
+        await page.getByRole("link", { name: "icon KeM's Toys" }).click();
+        await page
+          .getByRole("link", { name: "世界樹の暦 今日は何ノ月？" })
+          .click();
+
+        // Assert
+        await expect(page.getByText("セトハ").first()).toBeVisible();
+
+        // Cleanup
+        await page.evaluate(
+          (key) => localStorage.removeItem(key),
+          ETRIAN_REGISTRY_STORAGE_KEY,
+        );
+      });
+    });
+
+    test.describe.skip("タスク作成時のテスト", () => {});
+  });
+});

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -20,6 +20,7 @@ test.describe("世界樹の暦ページのテスト", () => {
             },
             affiliations: ["ブレイバント", "アルカディア"],
             order: 0,
+            memo: "アルカディアの冒険者。没落貴族の一人娘。",
           },
         ];
         await page.evaluate(
@@ -40,6 +41,9 @@ test.describe("世界樹の暦ページのテスト", () => {
         await expect(page.getByText("皇帝ノ月 1 日").first()).toBeVisible();
         await expect(page.getByText("ブレイバント").first()).toBeVisible();
         await expect(page.getByText("アルカディア").first()).toBeVisible();
+        await expect(
+          page.getByText("アルカディアの冒険者。没落貴族の一人娘。").first(),
+        ).toBeVisible();
 
         // Cleanup
         await page.evaluate(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: "http://localhost:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     // TODO: 推奨のエビデンス記録に揃える？ https://github.com/kem198/kems-todos/pull/31#discussion_r2442717664


### PR DESCRIPTION
This pull request introduces an end-to-end (E2E) test for the Etrian Calendar feature and updates the Playwright configuration to set a base URL. The new test ensures that the adventurer registry displays correct information on initial load, improving test coverage for user data persistence and display.

**E2E Test Additions:**

- Added a Playwright test (`page.spec.ts`) for the Etrian Calendar's adventurer birthday registry, verifying that stored adventurer data is correctly displayed on the initial page load. The test sets up local storage, navigates to the calendar, and checks for the presence of expected adventurer details.

**Configuration Updates:**

- Set the `baseURL` to `"http://localhost:3000"` in `playwright.config.ts` to standardize navigation for all Playwright tests.