### PR TITLE
Feature/update etrian calendar

### DIFF
--- a/src/app/(toys)/etrian-calendar/_common/constants/color.ts
+++ b/src/app/(toys)/etrian-calendar/_common/constants/color.ts
@@ -7,28 +7,33 @@ export type MonthColorKey = EtrianMonthName | EtrianNewYearsEveName | "default";
 
 export const BIRTHDAY_COLOR_VARIANTS = {
   default: "bg-zinc-100 text-zinc-500 hover:bg-zinc-100",
-  kotei: "bg-sky-100 text-sky-700 hover:bg-sky-100",
-  sakura: "bg-pink-50 text-pink-500 hover:bg-pink-50",
-  koseki: "bg-green-100 text-lime-700 hover:bg-green-100",
-  johi: "bg-orange-100 text-red-700 hover:bg-orange-100",
-  rikka: "bg-slate-100 text-sky-600 hover:bg-slate-100",
-  monoka: "bg-rose-200 text-rose-700 hover:bg-rose-200",
+  emperor:
+    "bg-etrian-emperor text-etrian-emperor-foreground hover:bg-etrian-emperor",
+  spring:
+    "bg-etrian-spring text-etrian-spring-foreground hover:bg-etrian-spring",
+  summer:
+    "bg-etrian-summer text-etrian-summer-foreground hover:bg-etrian-summer",
+  fall: "bg-etrian-fall text-etrian-fall-foreground hover:bg-etrian-fall",
+  winter:
+    "bg-etrian-winter text-etrian-winter-foreground hover:bg-etrian-winter",
+  summoner:
+    "bg-etrian-summoner text-etrian-summoner-foreground hover:bg-etrian-summoner",
 } as const;
 
 export const BIRTHDAY_CLASS_BY_MONTH: Record<MonthColorKey, string> = {
   default: BIRTHDAY_COLOR_VARIANTS.default,
-  皇帝ノ月: BIRTHDAY_COLOR_VARIANTS.kotei,
-  笛鼠ノ月: BIRTHDAY_COLOR_VARIANTS.sakura,
-  天牛ノ月: BIRTHDAY_COLOR_VARIANTS.sakura,
-  王虎ノ月: BIRTHDAY_COLOR_VARIANTS.sakura,
-  素兎ノ月: BIRTHDAY_COLOR_VARIANTS.koseki,
-  虹竜ノ月: BIRTHDAY_COLOR_VARIANTS.koseki,
-  白蛇ノ月: BIRTHDAY_COLOR_VARIANTS.koseki,
-  風馬ノ月: BIRTHDAY_COLOR_VARIANTS.johi,
-  金羊ノ月: BIRTHDAY_COLOR_VARIANTS.johi,
-  飛猴ノ月: BIRTHDAY_COLOR_VARIANTS.johi,
-  火鳥ノ月: BIRTHDAY_COLOR_VARIANTS.rikka,
-  戌神ノ月: BIRTHDAY_COLOR_VARIANTS.rikka,
-  怒猪ノ月: BIRTHDAY_COLOR_VARIANTS.rikka,
-  鬼乎ノ日: BIRTHDAY_COLOR_VARIANTS.monoka,
+  皇帝ノ月: BIRTHDAY_COLOR_VARIANTS.emperor,
+  笛鼠ノ月: BIRTHDAY_COLOR_VARIANTS.spring,
+  天牛ノ月: BIRTHDAY_COLOR_VARIANTS.spring,
+  王虎ノ月: BIRTHDAY_COLOR_VARIANTS.spring,
+  素兎ノ月: BIRTHDAY_COLOR_VARIANTS.summer,
+  虹竜ノ月: BIRTHDAY_COLOR_VARIANTS.summer,
+  白蛇ノ月: BIRTHDAY_COLOR_VARIANTS.summer,
+  風馬ノ月: BIRTHDAY_COLOR_VARIANTS.fall,
+  金羊ノ月: BIRTHDAY_COLOR_VARIANTS.fall,
+  飛猴ノ月: BIRTHDAY_COLOR_VARIANTS.fall,
+  火鳥ノ月: BIRTHDAY_COLOR_VARIANTS.winter,
+  戌神ノ月: BIRTHDAY_COLOR_VARIANTS.winter,
+  怒猪ノ月: BIRTHDAY_COLOR_VARIANTS.winter,
+  鬼乎ノ日: BIRTHDAY_COLOR_VARIANTS.summoner,
 } as const;

--- a/src/app/(toys)/etrian-calendar/page.mdx
+++ b/src/app/(toys)/etrian-calendar/page.mdx
@@ -51,6 +51,7 @@ import { Version } from "@/components/shared/version";
   >
   > 出展『世界樹の迷宮Ⅳ伝承の巨人公式マスターズガイド）
 
+- [Time \| Etrian Odyssey Wiki \| Fandom](https://etrian.fandom.com/wiki/Time)
 - [ウェブストレージ API - Web API \| MDN](https://developer.mozilla.org/ja/docs/Web/API/Web_Storage_API)
   - [Window: localStorage プロパティ - Web API \| MDN](https://developer.mozilla.org/ja/docs/Web/API/Window/localStorage)
 - [kem198/practice-web-storage-api](https://github.com/kem198/practice-web-storage-api)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,18 @@
     --personal-foreground: 0 0% 98%;
     --modane: 0 100% 73%; /* ff7777 */
     --modane-foreground: 0 0% 98%;
+    --etrian-emperor: 160 80% 84%;
+    --etrian-emperor-foreground: 180 66% 25%;
+    --etrian-spring: 65 67% 79%;
+    --etrian-spring-foreground: 110 33% 35%;
+    --etrian-summer: 150 70% 75%;
+    --etrian-summer-foreground: 150 59% 30%;
+    --etrian-fall: 42 99% 75%;
+    --etrian-fall-foreground: 42 67% 28%;
+    --etrian-winter: 176 60% 70%;
+    --etrian-winter-foreground: 176 27% 30%;
+    --etrian-summoner: 326 65% 70%;
+    --etrian-summoner-foreground: 339 20% 14%;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -83,6 +95,24 @@
     --personal-foreground: 0 0% 98%;
     --modane: 0 100% 73%; /* ff7777 */
     --modane-foreground: 0 0% 98%;
+    --etrian-emperor-top: 0 0% 0%; /*  */
+    --etrian-emperor-bottom: 0 0% 0%; /*  */
+    --etrian-emperor-foreground: 0 0% 0%; /*  */
+    --etrian-spring-top: 0 100% 73%; /* fdfcb1 */
+    --etrian-spring-bottom: 139 51% 65%; /* 7ad497 */
+    --etrian-spring-foreground: 159 33% 24%; /* 285042 */
+    --etrian-summer-top: 99 42% 76%; /* bbdca9 */
+    --etrian-summer-bottom: 173 32% 49%; /* 56a69d */
+    --etrian-summer-foreground: 205 59% 27%; /* 1d4d6f */
+    --etrian-fall-top: 0 0% 0%; /*  */
+    --etrian-fall-bottom: 0 0% 0%; /*  */
+    --etrian-fall-foreground: 0 0% 0%; /*  */
+    --etrian-winter-top: 0 0% 0%; /*  */
+    --etrian-winter-bottom: 0 0% 0%; /*  */
+    --etrian-winter-foreground: 0 0% 0%; /*  */
+    --etrian-summoner-top: 0 0% 0%; /*  */
+    --etrian-summoner-bottom: 0 0% 0%; /*  */
+    --etrian-summoner-foreground: 0 0% 0%; /*  */
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,6 +85,32 @@ const config: Config = {
           DEFAULT: "hsl(var(--modane))",
           foreground: "hsl(var(--modane-foreground))",
         },
+        etrian: {
+          emperor: {
+            DEFAULT: "hsl(var(--etrian-emperor))",
+            foreground: "hsl(var(--etrian-emperor-foreground))",
+          },
+          spring: {
+            DEFAULT: "hsl(var(--etrian-spring))",
+            foreground: "hsl(var(--etrian-spring-foreground))",
+          },
+          summer: {
+            DEFAULT: "hsl(var(--etrian-summer))",
+            foreground: "hsl(var(--etrian-summer-foreground))",
+          },
+          fall: {
+            DEFAULT: "hsl(var(--etrian-fall))",
+            foreground: "hsl(var(--etrian-fall-foreground))",
+          },
+          winter: {
+            DEFAULT: "hsl(var(--etrian-winter))",
+            foreground: "hsl(var(--etrian-winter-foreground))",
+          },
+          summoner: {
+            DEFAULT: "hsl(var(--etrian-summoner))",
+            foreground: "hsl(var(--etrian-summoner-foreground))",
+          },
+        },
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
This pull request updates the Etrian Calendar color system to use new thematic color keys (emperor, spring, summer, fall, winter, summoner) for months and special days, and adds support for these colors in both CSS and Tailwind configuration. It also adds a new reference link to the related Etrian Odyssey Wiki. The main changes are grouped below:

**Color System Refactor:**

* Replaced old month color keys (e.g., `kotei`, `sakura`, etc.) with new thematic keys (`emperor`, `spring`, `summer`, `fall`, `winter`, `summoner`) in `BIRTHDAY_COLOR_VARIANTS` and updated the mapping in `BIRTHDAY_CLASS_BY_MONTH` in `color.ts`.
* Added new CSS variables for the Etrian month and summoner colors and their foregrounds in `globals.css` for both light and dark themes. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R46-R57) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R98-R115)
* Added corresponding color definitions to the Tailwind configuration under the `etrian` namespace, enabling usage of these new colors in Tailwind utility classes.

**Documentation:**

* Added a new reference link to the "Time" page on the Etrian Odyssey Wiki in the documentation (`page.mdx`).