### PR TITLE
fix: update calendar component to correctly set date range and defaul…

### DIFF
--- a/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
@@ -17,7 +17,10 @@ import React from "react";
 export function SolarEtrianCalendarConverter() {
   const [open, setOpen] = React.useState(false);
   const [date, setDate] = React.useState<Date | undefined>(new Date());
+
+  const startMonth = new Date(2007, 0);
   const currentYear = new Date().getFullYear();
+  const endMonth = new Date(currentYear + 4, 11);
 
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -48,8 +51,8 @@ export function SolarEtrianCalendarConverter() {
                   captionLayout="dropdown"
                   selected={date}
                   defaultMonth={date}
-                  startMonth={new Date(2007, 0)}
-                  endMonth={new Date(currentYear + 4, 11)}
+                  startMonth={startMonth}
+                  endMonth={endMonth}
                   onSelect={(selectedDate) => {
                     setDate(selectedDate);
                     setOpen(false);

--- a/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
@@ -17,6 +17,7 @@ import React from "react";
 export function SolarEtrianCalendarConverter() {
   const [open, setOpen] = React.useState(false);
   const [date, setDate] = React.useState<Date | undefined>(new Date());
+  const currentYear = new Date().getFullYear();
 
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -44,8 +45,11 @@ export function SolarEtrianCalendarConverter() {
               >
                 <Calendar
                   mode="single"
-                  selected={date}
                   captionLayout="dropdown"
+                  selected={date}
+                  defaultMonth={date}
+                  startMonth={new Date(2007, 0)}
+                  endMonth={new Date(currentYear + 4, 11)}
                   onSelect={(selectedDate) => {
                     setDate(selectedDate);
                     setOpen(false);

--- a/src/app/(toys)/etrian-calendar/page.mdx
+++ b/src/app/(toys)/etrian-calendar/page.mdx
@@ -57,4 +57,4 @@ import { Version } from "@/components/shared/version";
 - [kem198/practice-web-storage-api](https://github.com/kem198/practice-web-storage-api)
 - [Next.js で Hydration Error が起きる理由と解決方法](https://zenn.dev/luvmini511/articles/71f65df05716ca)
 
-<Version version="0.2.0" onDate="2025-11-03" />
+<Version version="0.2.1" onDate="2025-11-06" />


### PR DESCRIPTION
This pull request updates the `SolarEtrianCalendarConverter` component to improve the calendar's date range and default month behavior. The most important changes are:

Calendar configuration improvements:

* The calendar now has a dynamic date range: it starts from January 2007 and ends in December of four years beyond the current year, making it more flexible and future-proof.
* The calendar's `defaultMonth` is now set to the currently selected date, ensuring the calendar opens on the right month.

Code enhancements:

* Introduced a `currentYear` variable to simplify date calculations and improve code readability.…t month