### PR TITLE
Feature/mod etrian converter

### DIFF
--- a/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
@@ -27,7 +27,13 @@ import {
 } from "@/components/ui/select";
 import { isLeapYear } from "@/utilities/date-utils";
 import { format } from "date-fns";
-import { ArrowRightLeft, ChevronDownIcon, Sprout, Sun } from "lucide-react";
+import {
+  ArrowDownUp,
+  ArrowRightLeft,
+  ChevronDownIcon,
+  Sprout,
+  Sun,
+} from "lucide-react";
 import React, { useState } from "react";
 
 export function ToEtrianCalendarConverter() {
@@ -260,7 +266,8 @@ export function SolarEtrianCalendarConverter() {
           setIsShowToEtrian(!isShowToEtrian);
         }}
       >
-        <ArrowRightLeft />
+        <ArrowDownUp className="block md:hidden" />
+        <ArrowRightLeft className="hidden md:block" />
         入れ替える
       </Button>
     </div>

--- a/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
@@ -39,7 +39,7 @@ export function ToEtrianCalendarConverter() {
   const endMonth = new Date(currentYear + 4, 11);
 
   return (
-    <ItemContent className="flex flex-row flex-wrap gap-4">
+    <ItemContent className="flex flex-col flex-wrap gap-4 md:flex-row">
       <div className="flex flex-1 flex-col gap-2">
         <Label htmlFor="date" className="flex items-center gap-1">
           <Sun size={16} />
@@ -167,7 +167,7 @@ export function ToSolarCalendarConverter() {
   }, [selectedYear, selectedMonth, selectedDay, maxDay]);
 
   return (
-    <ItemContent className="flex flex-row flex-wrap gap-4">
+    <ItemContent className="flex flex-col flex-wrap gap-4 md:flex-row">
       <div className="flex flex-1 flex-col gap-2">
         <Label htmlFor="etrian-month" className="flex items-center gap-1">
           <Sprout size={16} />

--- a/src/app/(toys)/etrian-calendar/page.mdx
+++ b/src/app/(toys)/etrian-calendar/page.mdx
@@ -57,4 +57,4 @@ import { Version } from "@/components/shared/version";
 - [kem198/practice-web-storage-api](https://github.com/kem198/practice-web-storage-api)
 - [Next.js で Hydration Error が起きる理由と解決方法](https://zenn.dev/luvmini511/articles/71f65df05716ca)
 
-<Version version="0.3.0" onDate="2025-11-06" />
+<Version version="0.3.1" onDate="2025-11-06" />


### PR DESCRIPTION
This pull request updates the Etrian Calendar converter UI to improve its responsiveness and iconography, and bumps the version number to reflect these changes. The layout now adapts better to different screen sizes, and the swap button icon changes based on the device.

UI improvements for responsiveness and clarity:

* Updated layout in both `ToEtrianCalendarConverter` and `ToSolarCalendarConverter` to use a column layout on small screens and a row layout on medium and larger screens by changing the `ItemContent` class names. [[1]](diffhunk://#diff-7add9ef29ecaa42db1db021f7e8536f994e4d3abc5e4ca7117ec840200293e88L42-R48) [[2]](diffhunk://#diff-7add9ef29ecaa42db1db021f7e8536f994e4d3abc5e4ca7117ec840200293e88L170-R176)
* Modified the swap button in `SolarEtrianCalendarConverter` to display `ArrowDownUp` on mobile and `ArrowRightLeft` on desktop for better visual cues, and added the new icon to the imports. [[1]](diffhunk://#diff-7add9ef29ecaa42db1db021f7e8536f994e4d3abc5e4ca7117ec840200293e88L30-R36) [[2]](diffhunk://#diff-7add9ef29ecaa42db1db021f7e8536f994e4d3abc5e4ca7117ec840200293e88L263-R270)

Version update:

* Updated the displayed version from `0.3.0` to `0.3.1` in `page.mdx` to reflect the latest changes.