### PR TITLE
Feature/etrian small update

### DIFF
--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -250,6 +250,114 @@ test.describe("世界樹の暦ページのテスト", () => {
           page.getByText("突剣を自在に扱う冒険者。没落貴族の一人娘。").first(),
         ).toBeVisible();
       });
+
+      test("今日が誕生月の状態で、画面が初期表示された時、「今月はお誕生月です！あと ? 日！」が表示されること", async ({
+        page,
+      }) => {
+        // Arrange
+        await page.clock.setFixedTime(new Date("2024-01-14T10:00:00"));
+        const etrians: Etrian[] = [
+          {
+            id: "test-etrian",
+            name: "セトハ",
+            dateOfBirth: {
+              month: "皇帝ノ月",
+              day: 15,
+            },
+            affiliations: ["ブレイバント", "アルカディア"],
+            order: 0,
+            memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
+          },
+        ];
+        await page.evaluate(
+          ([key, value]) => {
+            localStorage.setItem(key, value);
+          },
+          [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
+        );
+
+        // Act
+        await page
+          .getByRole("link", { name: "世界樹の暦 今日は何ノ月？" })
+          .click();
+
+        // Assert
+        await expect(
+          page.getByText("今月はお誕生月です！あと 1 日！").first(),
+        ).toBeVisible();
+      });
+
+      test("今日が誕生日の状態で、画面が初期表示された時、「🎉お誕生日です！おめでとう！」が表示されること", async ({
+        page,
+      }) => {
+        // Arrange
+        await page.clock.setFixedTime(new Date("2024-01-15T10:00:00"));
+        const etrians: Etrian[] = [
+          {
+            id: "test-etrian",
+            name: "セトハ",
+            dateOfBirth: {
+              month: "皇帝ノ月",
+              day: 15,
+            },
+            affiliations: ["ブレイバント", "アルカディア"],
+            order: 0,
+            memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
+          },
+        ];
+        await page.evaluate(
+          ([key, value]) => {
+            localStorage.setItem(key, value);
+          },
+          [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
+        );
+
+        // Act
+        await page
+          .getByRole("link", { name: "世界樹の暦 今日は何ノ月？" })
+          .click();
+
+        // Assert
+        await expect(
+          page.getByText("🎉お誕生日です！おめでとう！").first(),
+        ).toBeVisible();
+      });
+
+      test("今日が誕生月かつ誕生日が過ぎている状態で、画面が初期表示された時、「今月はお誕生月でした！また来年！」が表示されること", async ({
+        page,
+      }) => {
+        // Arrange
+        await page.clock.setFixedTime(new Date("2024-01-16T10:00:00"));
+        const etrians: Etrian[] = [
+          {
+            id: "test-etrian",
+            name: "セトハ",
+            dateOfBirth: {
+              month: "皇帝ノ月",
+              day: 15,
+            },
+            affiliations: ["ブレイバント", "アルカディア"],
+            order: 0,
+            memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
+          },
+        ];
+        await page.evaluate(
+          ([key, value]) => {
+            localStorage.setItem(key, value);
+          },
+          [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
+        );
+
+        // Act
+        await page
+          .getByRole("link", { name: "世界樹の暦 今日は何ノ月？" })
+          .click();
+
+        // Assert
+        await expect(
+          page.getByText("今月はお誕生月でした！また来年！").first(),
+        ).toBeVisible();
+      });
     });
 
     test.describe.skip("作成時のテスト", () => {});

--- a/src/app/(toys)/etrian-calendar/_common/constants/date.ts
+++ b/src/app/(toys)/etrian-calendar/_common/constants/date.ts
@@ -61,8 +61,8 @@ export const etrianNewYearsEve = {
 export const etrianMonthOptionValues = [
   ...etrianMonths.map((month) => month.name),
   etrianNewYearsEve.name,
-];
+] as const;
 
-export const etrianDayOptionValues = Array.from({ length: 28 }, (_, index) =>
-  String(index + 1),
-);
+export const etrianDayOptionValues = [
+  ...Array.from({ length: 28 }, (_, index) => String(index + 1)),
+] as const;

--- a/src/app/(toys)/etrian-calendar/_common/constants/date.ts
+++ b/src/app/(toys)/etrian-calendar/_common/constants/date.ts
@@ -58,11 +58,14 @@ export const etrianNewYearsEve = {
   kana: "ものかのひ",
 } as const;
 
-export const etrianMonthOptionValues = [
+export const etrianMonthOptions = [
   ...etrianMonths.map((month) => month.name),
   etrianNewYearsEve.name,
 ] as const;
 
-export const etrianDayOptionValues = [
-  ...Array.from({ length: 28 }, (_, index) => String(index + 1)),
+export const etrianDays = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+  23, 24, 25, 26, 27, 28,
 ] as const;
+
+export const etrianDayOptions = etrianDays.map(String);

--- a/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
+++ b/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
@@ -6,11 +6,11 @@ import {
 
 export type EtrianMonthName = (typeof etrianMonths)[number]["name"];
 export type EtrianMonthNameKana = (typeof etrianMonths)[number]["kana"];
-export type EtrianNewYearsEveName = (typeof etrianNewYearsEve)["name"];
-export type EtrianNewYearsEveNameKana = (typeof etrianNewYearsEve)["kana"];
 export type EtrianMonthNameWithNewYearsEve =
   | EtrianMonthName
   | EtrianNewYearsEveName;
+export type EtrianNewYearsEveName = (typeof etrianNewYearsEve)["name"];
+export type EtrianNewYearsEveNameKana = (typeof etrianNewYearsEve)["kana"];
 
 export type EtrianDay = (typeof etrianDays)[number];
 

--- a/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
+++ b/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
@@ -7,6 +7,10 @@ export type EtrianMonthName = (typeof etrianMonths)[number]["name"];
 export type EtrianMonthNameKana = (typeof etrianMonths)[number]["kana"];
 export type EtrianNewYearsEveName = (typeof etrianNewYearsEve)["name"];
 export type EtrianNewYearsEveNameKana = (typeof etrianNewYearsEve)["kana"];
+export type EtrianMonthNameWithNewYearsEve =
+  | EtrianMonthName
+  | EtrianNewYearsEveName;
+
 export type EtrianDay =
   | 1
   | 2
@@ -38,7 +42,7 @@ export type EtrianDay =
   | 28;
 
 export type EtrianDateOfBirth = {
-  month?: EtrianMonthName | EtrianNewYearsEveName;
+  month?: EtrianMonthNameWithNewYearsEve;
   day?: EtrianDay;
 };
 

--- a/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
+++ b/src/app/(toys)/etrian-calendar/_common/types/etrian.ts
@@ -1,4 +1,5 @@
 import {
+  etrianDays,
   etrianMonths,
   etrianNewYearsEve,
 } from "@/app/(toys)/etrian-calendar/_common/constants/date";
@@ -11,35 +12,7 @@ export type EtrianMonthNameWithNewYearsEve =
   | EtrianMonthName
   | EtrianNewYearsEveName;
 
-export type EtrianDay =
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
-  | 13
-  | 14
-  | 15
-  | 16
-  | 17
-  | 18
-  | 19
-  | 20
-  | 21
-  | 22
-  | 23
-  | 24
-  | 25
-  | 26
-  | 27
-  | 28;
+export type EtrianDay = (typeof etrianDays)[number];
 
 export type EtrianDateOfBirth = {
   month?: EtrianMonthNameWithNewYearsEve;

--- a/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/converter/solar-etrian-calendar-converter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { etrianMonthOptionValues } from "@/app/(toys)/etrian-calendar/_common/constants/date";
+import { etrianMonthOptions } from "@/app/(toys)/etrian-calendar/_common/constants/date";
 import {
   EtrianDay,
   EtrianMonthName,
@@ -202,7 +202,7 @@ export function ToSolarCalendarConverter() {
                 <SelectValue placeholder="月を選択" />
               </SelectTrigger>
               <SelectContent>
-                {etrianMonthOptionValues.map((option) => (
+                {etrianMonthOptions.map((option) => (
                   <SelectItem key={option} value={option}>
                     {option}
                   </SelectItem>

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -15,7 +15,11 @@ import {
   etrianDayOptionValues,
   etrianMonthOptionValues,
 } from "@/app/(toys)/etrian-calendar/_common/constants/date";
-import { Etrian } from "@/app/(toys)/etrian-calendar/_common/types/etrian";
+import {
+  Etrian,
+  EtrianDay,
+  EtrianMonthNameWithNewYearsEve,
+} from "@/app/(toys)/etrian-calendar/_common/types/etrian";
 import {
   RegistryFormValues,
   registryFormSchema,
@@ -83,14 +87,41 @@ export function EditDialog({
       name: etrian.name,
       memo: etrian.memo,
       dateOfBirth: {
-        month: etrian.dateOfBirth.month ?? UNSET_SELECT_VALUE,
-        day: etrian.dateOfBirth.day
+        month: etrian.dateOfBirth?.month ?? UNSET_SELECT_VALUE,
+        day: etrian.dateOfBirth?.day
           ? String(etrian.dateOfBirth.day)
           : UNSET_SELECT_VALUE,
       },
       affiliations: etrian.affiliations?.join(","),
     });
   }, [etrian, form]);
+
+  const normalizeAffiliations = (
+    affiliationsString: string | undefined,
+  ): string[] => {
+    if (!affiliationsString) return [];
+    return affiliationsString
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+  };
+
+  const parseMonth = (
+    monthString: string | undefined,
+  ): EtrianMonthNameWithNewYearsEve | undefined => {
+    if (!monthString || monthString === UNSET_SELECT_VALUE) return undefined;
+    return etrianMonthOptionValues.includes(monthString as any)
+      ? (monthString as EtrianMonthNameWithNewYearsEve)
+      : undefined;
+  };
+
+  const parseDay = (dayStr: string | undefined): EtrianDay | undefined => {
+    if (!dayStr || dayStr === UNSET_SELECT_VALUE) return undefined;
+    const dayNumber = Number(dayStr);
+    return dayNumber >= 1 && dayNumber <= 28
+      ? (dayNumber as EtrianDay)
+      : undefined;
+  };
 
   useEffect(() => {
     if (!open) {
@@ -101,38 +132,15 @@ export function EditDialog({
   }, [open, resetFormValues]);
 
   const handleSubmit = (data: RegistryFormValues) => {
-    const normalizedAffiliations = (data.affiliations ?? "")
-      .split(",")
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-
-    const selectedMonth = data.dateOfBirth.month;
-    const isKnownMonth =
-      selectedMonth !== undefined &&
-      selectedMonth !== UNSET_SELECT_VALUE &&
-      (etrianMonthOptionValues as string[]).includes(selectedMonth);
-    const month = isKnownMonth
-      ? (selectedMonth as Etrian["dateOfBirth"]["month"])
-      : undefined;
-
-    const selectedDay = data.dateOfBirth.day;
-    const dayNumber =
-      selectedDay && selectedDay !== UNSET_SELECT_VALUE
-        ? Number(selectedDay)
-        : undefined;
-    const day =
-      dayNumber && dayNumber >= 1 && dayNumber <= 28
-        ? (dayNumber as Etrian["dateOfBirth"]["day"])
-        : undefined;
+    const normalizedAffiliations = normalizeAffiliations(data.affiliations);
+    const month = parseMonth(data.dateOfBirth.month);
+    const day = parseDay(data.dateOfBirth.day);
 
     const updatedEtrian: Etrian = {
       ...etrian,
       name: data.name.trim(),
       affiliations: normalizedAffiliations,
-      dateOfBirth: {
-        month,
-        day,
-      },
+      dateOfBirth: { month, day },
       memo: data.memo?.trim(),
     };
 

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -12,8 +12,8 @@ import {
 import { Controller, useForm } from "react-hook-form";
 
 import {
-  etrianDayOptionValues,
-  etrianMonthOptionValues,
+  etrianDayOptions,
+  etrianMonthOptions,
 } from "@/app/(toys)/etrian-calendar/_common/constants/date";
 import {
   Etrian,
@@ -110,7 +110,7 @@ export function EditDialog({
     monthString: string | undefined,
   ): EtrianMonthNameWithNewYearsEve | undefined => {
     if (!monthString || monthString === UNSET_SELECT_VALUE) return undefined;
-    return etrianMonthOptionValues.includes(monthString as any)
+    return etrianMonthOptions.includes(monthString as any)
       ? (monthString as EtrianMonthNameWithNewYearsEve)
       : undefined;
   };
@@ -206,15 +206,13 @@ export function EditDialog({
                         onValueChange={field.onChange}
                       >
                         <SelectTrigger id="etrian-birth-month">
-                          <SelectValue
-                            placeholder={etrianMonthOptionValues[0]}
-                          />
+                          <SelectValue placeholder={etrianMonthOptions[0]} />
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value={UNSET_SELECT_VALUE}>
                             {UNSET_SELECT_VALUE}
                           </SelectItem>
-                          {etrianMonthOptionValues.map((option) => (
+                          {etrianMonthOptions.map((option) => (
                             <SelectItem key={option} value={option}>
                               {option}
                             </SelectItem>
@@ -243,7 +241,7 @@ export function EditDialog({
                             <SelectItem value={UNSET_SELECT_VALUE}>
                               {UNSET_SELECT_VALUE}
                             </SelectItem>
-                            {etrianDayOptionValues.map((option) => (
+                            {etrianDayOptions.map((option) => (
                               <SelectItem key={option} value={option}>
                                 {option}
                               </SelectItem>

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -18,7 +18,6 @@ import {
 import { Etrian } from "@/app/(toys)/etrian-calendar/_common/types/etrian";
 import {
   RegistryFormValues,
-  UNSET_SELECT_VALUE,
   registryFormSchema,
 } from "@/app/(toys)/etrian-calendar/_features/registry/schemas/registry-form-schema";
 import { Required } from "@/components/shared/required";
@@ -50,6 +49,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { UNSET_SELECT_VALUE } from "@/constants/select";
 
 type EditDialogProps = {
   etrian: Etrian;

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -110,7 +110,7 @@ export function EditDialog({
     monthString: string | undefined,
   ): EtrianMonthNameWithNewYearsEve | undefined => {
     if (!monthString || monthString === UNSET_SELECT_VALUE) return undefined;
-    return etrianMonthOptions.includes(monthString as any)
+    return (etrianMonthOptions as readonly string[]).includes(monthString)
       ? (monthString as EtrianMonthNameWithNewYearsEve)
       : undefined;
   };

--- a/src/app/(toys)/etrian-calendar/_features/registry/schemas/registry-form-schema.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/schemas/registry-form-schema.ts
@@ -1,6 +1,5 @@
+import { UNSET_SELECT_VALUE } from "@/constants/select";
 import * as z from "zod";
-
-export const UNSET_SELECT_VALUE = "未設定";
 
 export const registryFormSchema = z
   .object({

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -13,12 +13,12 @@ const Avatar = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className
+      className,
     )}
     {...props}
   />
-))
-Avatar.displayName = AvatarPrimitive.Root.displayName
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
 
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
@@ -29,8 +29,8 @@ const AvatarImage = React.forwardRef<
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
-))
-AvatarImage.displayName = AvatarPrimitive.Image.displayName
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
 const AvatarFallback = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Fallback>,
@@ -40,11 +40,11 @@ const AvatarFallback = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-full w-full items-center justify-center rounded-full bg-muted",
-      className
+      className,
     )}
     {...props}
   />
-))
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarFallback, AvatarImage };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -10,12 +10,12 @@ const Card = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-xl border bg-card text-card-foreground shadow",
-      className
+      className,
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -26,8 +26,8 @@ const CardHeader = React.forwardRef<
     className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   HTMLDivElement,
@@ -38,8 +38,8 @@ const CardTitle = React.forwardRef<
     className={cn("font-semibold leading-none tracking-tight", className)}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<
   HTMLDivElement,
@@ -50,16 +50,16 @@ const CardDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+));
+CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -70,7 +70,14 @@ const CardFooter = React.forwardRef<
     className={cn("flex items-center p-6 pt-0", className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -19,8 +19,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&>span]:line-clamp-1",
+      className,
     )}
     {...props}
   >
@@ -29,8 +29,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -40,14 +40,14 @@ const SelectScrollUpButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
-      className
+      className,
     )}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -57,15 +57,15 @@ const SelectScrollDownButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
-      className
+      className,
     )}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
+));
 SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -75,10 +75,10 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className
+        className,
       )}
       position={position}
       {...props}
@@ -88,7 +88,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
         )}
       >
         {children}
@@ -96,8 +96,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -108,8 +108,8 @@ const SelectLabel = React.forwardRef<
     className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -119,7 +119,7 @@ const SelectItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -130,8 +130,8 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -142,18 +142,18 @@ const SelectSeparator = React.forwardRef<
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
-  SelectGroup,
-  SelectValue,
-  SelectTrigger,
   SelectContent,
-  SelectLabel,
+  SelectGroup,
   SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
+  SelectLabel,
   SelectScrollDownButton,
-}
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/constants/select.ts
+++ b/src/constants/select.ts
@@ -1,0 +1,1 @@
+export const UNSET_SELECT_VALUE = "未設定";


### PR DESCRIPTION
This pull request adds new end-to-end tests for birthday-related messages in the Etrian Calendar feature and refactors the handling of the unset select value constant to improve maintainability and consistency. The most important changes are:

**Testing improvements:**

* Added three new tests to `page.spec.ts` verifying that the correct birthday and birth month messages are displayed depending on the current date and the Etrian's date of birth. These tests check for messages shown on the birthday, during the birth month before and after the birthday.

**Codebase consistency and refactoring:**

* Moved the `UNSET_SELECT_VALUE` constant to a new file, `src/constants/select.ts`, and updated all imports to use this centralized definition instead of duplicating it in multiple places. [[1]](diffhunk://#diff-fa515a39a0d792281a1787ab204e5e1bfda58f6f4e8b50b895830df3b1f7e1dbR1) [[2]](diffhunk://#diff-5de2cc6c4fc7e056abefde1e2ab1bfeca2d42be6016ce707216d565e7b057061R1-L4) [[3]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093L21) [[4]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093R52)
* Updated the definition of `etrianMonthOptionValues` and `etrianDayOptionValues` in `date.ts` to use `as const`, ensuring these arrays are treated as readonly tuples for improved type safety.This pull request adds new tests for birthday-related messages in the Etrian Calendar feature and refactors the handling of the unset select value constant for better maintainability and type safety.

**Testing improvements:**

* Added three new end-to-end tests in `page.spec.ts` to verify the correct display of messages when today is (1) before, (2) on, and (3) after a character's birthday within their birth month.

**Refactoring and constants:**

* Moved the `UNSET_SELECT_VALUE` constant to a new shared location (`src/constants/select.ts`) and updated all imports and references to use this centralized definition for consistency. [[1]](diffhunk://#diff-5de2cc6c4fc7e056abefde1e2ab1bfeca2d42be6016ce707216d565e7b057061R1-L4) [[2]](diffhunk://#diff-fa515a39a0d792281a1787ab204e5e1bfda58f6f4e8b50b895830df3b1f7e1dbR1) [[3]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093L21) [[4]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093R52)
* Updated `etrianMonthOptionValues` and `etrianDayOptionValues` in `date.ts` to use `as const` for improved type safety.