### PR TITLE
Feature/mod etrians

### DIFF
--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/backup-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/backup-dialog.tsx
@@ -31,7 +31,7 @@ export function BackupDialog({
           <DialogDescription>
             ブラウザ (localStorage) 上に保存されている情報を表示します。
             <br />
-            コピーしておくと復元しやすい……かも。
+            コピーしておくと安心……かも。
           </DialogDescription>
         </DialogHeader>
 

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/backup-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/backup-dialog.tsx
@@ -1,4 +1,4 @@
-import { Etrian } from "@/app/(toys)/etrian-calendar/_common/types/etrian";
+import { EtrianRegistry } from "@/app/(toys)/etrian-calendar/_common/types/etrian";
 import { JsonDisplay } from "@/components/shared/json-display";
 import {
   Dialog,
@@ -11,12 +11,12 @@ import {
 import { ComponentProps, ReactNode } from "react";
 
 type BackupDialogProps = {
-  storedEtrians: Etrian[];
+  storedEtrianRegistry: EtrianRegistry;
   children: ReactNode;
 } & ComponentProps<typeof DialogTrigger>;
 
 export function BackupDialog({
-  storedEtrians,
+  storedEtrianRegistry,
   children,
   ...props
 }: BackupDialogProps) {
@@ -36,7 +36,7 @@ export function BackupDialog({
         </DialogHeader>
 
         <JsonDisplay
-          data={storedEtrians}
+          data={storedEtrianRegistry}
           scrollAreaProps={{ className: "max-h-[60vh]" }}
         />
       </DialogContent>

--- a/src/app/(toys)/etrian-calendar/_features/registry/etrian-registry.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/etrian-registry.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 export function EtrianRegistry() {
   const {
     storedEtrians,
+    storedEtrianRegistry,
     isLoaded,
     migrationError,
     addEtrian,
@@ -182,7 +183,10 @@ export function EtrianRegistry() {
                 >
                   <Button variant="destructive">リセット</Button>
                 </ConfirmDialog>
-                <BackupDialog storedEtrians={storedEtrians} className="w-fit">
+                <BackupDialog
+                  storedEtrianRegistry={storedEtrianRegistry}
+                  className="w-fit"
+                >
                   <Button variant="secondary">バックアップ</Button>
                 </BackupDialog>
               </>

--- a/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
@@ -85,7 +85,7 @@ export function useEtrianRegistry(
       version: CURRENT_ETRIAN_REGISTRY_VERSION,
       etrians: storedEtrians,
     };
-
+    setStoredEtrianRegistry(registry);
     window.localStorage.setItem(storageKey, JSON.stringify(registry));
   }, [storedEtrians, isLoaded, storageKey]);
 

--- a/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
@@ -66,10 +66,10 @@ export function useEtrianRegistry(
     } catch {
       // マイグレーション処理に失敗した場合、元のデータを保持してエラー状態を設定する
       setMigrationError({
+        // MigrationErrorDialog を表示する
         hasError: true,
         originalData: data,
       });
-      setStoredEtrianRegistry(null);
       setStoredEtrians([]);
       setStoredEtrianRegistry(null);
     } finally {
@@ -109,6 +109,7 @@ export function useEtrianRegistry(
 
   const resetEtrians = useCallback(() => {
     setStoredEtrians([]);
+    setStoredEtrianRegistry(null);
   }, []);
 
   const clearMigrationError = useCallback(() => {

--- a/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
@@ -71,6 +71,7 @@ export function useEtrianRegistry(
       });
       setStoredEtrianRegistry(null);
       setStoredEtrians([]);
+      setStoredEtrianRegistry(null);
     } finally {
       setIsLoaded(true);
     }

--- a/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/hooks/use-etrian-registry.ts
@@ -15,6 +15,7 @@ type UseEtrianRegistryOptions = {
 
 type UseEtrianRegistryReturn = {
   storedEtrians: Etrian[];
+  storedEtrianRegistry: EtrianRegistry;
   isLoaded: boolean;
   migrationError: {
     hasError: boolean;
@@ -34,6 +35,8 @@ export function useEtrianRegistry(
   const { storageKey = ETRIAN_REGISTRY_STORAGE_KEY } = options;
 
   const [storedEtrians, setStoredEtrians] = useState<Etrian[]>([]);
+  const [storedEtrianRegistry, setStoredEtrianRegistry] =
+    useState<EtrianRegistry | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [migrationError, setMigrationError] = useState<{
     hasError: boolean;
@@ -54,8 +57,10 @@ export function useEtrianRegistry(
       if (data) {
         const parsedData = JSON.parse(data);
         const migratedRegistry = migrateEtrianRegistry(parsedData);
+        setStoredEtrianRegistry(migratedRegistry);
         setStoredEtrians(migratedRegistry.etrians);
       } else {
+        setStoredEtrianRegistry(null);
         setStoredEtrians([]);
       }
     } catch {
@@ -64,6 +69,7 @@ export function useEtrianRegistry(
         hasError: true,
         originalData: data,
       });
+      setStoredEtrianRegistry(null);
       setStoredEtrians([]);
     } finally {
       setIsLoaded(true);
@@ -113,6 +119,10 @@ export function useEtrianRegistry(
 
   return {
     storedEtrians,
+    storedEtrianRegistry: storedEtrianRegistry ?? {
+      version: CURRENT_ETRIAN_REGISTRY_VERSION,
+      etrians: storedEtrians,
+    },
     isLoaded,
     migrationError,
     addEtrian,

--- a/src/app/(toys)/etrian-calendar/page.mdx
+++ b/src/app/(toys)/etrian-calendar/page.mdx
@@ -58,4 +58,4 @@ import { Version } from "@/components/shared/version";
 - [kem198/practice-web-storage-api](https://github.com/kem198/practice-web-storage-api)
 - [Next.js で Hydration Error が起きる理由と解決方法](https://zenn.dev/luvmini511/articles/71f65df05716ca)
 
-<Version version="0.4.0" onDate="2025-11-15" />
+<Version version="0.4.1" onDate="2025-11-15" />


### PR DESCRIPTION
This pull request updates the backup dialog in the Etrian Calendar app to use the full `EtrianRegistry` object instead of just the list of `Etrian` entries. The change ensures that backups include all relevant registry metadata, not just the array of entries. It also updates the custom hook and component props to support this change, and bumps the app version.

**Backup and Registry Data Handling:**

* Changed the `BackupDialog` component to accept and display the entire `EtrianRegistry` object instead of just the `Etrian[]` array, ensuring that backups include all registry metadata. [[1]](diffhunk://#diff-06c00038b871ad520eb260a38e0f709f19c83939c332a21550231cba3ec40c58L1-R1) [[2]](diffhunk://#diff-06c00038b871ad520eb260a38e0f709f19c83939c332a21550231cba3ec40c58L14-R19) [[3]](diffhunk://#diff-06c00038b871ad520eb260a38e0f709f19c83939c332a21550231cba3ec40c58L39-R39) [[4]](diffhunk://#diff-3e01c9d1b31b190d3f384d36dcde1c110880887928806cc68b667d74d2affb25L185-R189)
* Updated the `useEtrianRegistry` hook to provide both `storedEtrians` and the full `storedEtrianRegistry` in its return value, initializing and updating both appropriately based on storage and migration outcomes. [[1]](diffhunk://#diff-c4676f0361b8bfadd3fb3ed6fb478e62f34e8f98c306b974af81d3203714df3cR18) [[2]](diffhunk://#diff-c4676f0361b8bfadd3fb3ed6fb478e62f34e8f98c306b974af81d3203714df3cR38-R39) [[3]](diffhunk://#diff-c4676f0361b8bfadd3fb3ed6fb478e62f34e8f98c306b974af81d3203714df3cR60-R63) [[4]](diffhunk://#diff-c4676f0361b8bfadd3fb3ed6fb478e62f34e8f98c306b974af81d3203714df3cR72) [[5]](diffhunk://#diff-c4676f0361b8bfadd3fb3ed6fb478e62f34e8f98c306b974af81d3203714df3cR122-R125)

**UI and Versioning:**

* Updated the usage of `BackupDialog` in the registry UI to pass the new `storedEtrianRegistry` prop. [[1]](diffhunk://#diff-3e01c9d1b31b190d3f384d36dcde1c110880887928806cc68b667d74d2affb25R23) [[2]](diffhunk://#diff-3e01c9d1b31b190d3f384d36dcde1c110880887928806cc68b667d74d2affb25L185-R189)
* Bumped the app version from `0.4.0` to `0.4.1` to reflect these improvements.