### PR TITLE
fix: increase worker count for parallel test execution in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
This pull request makes a small configuration change to the Playwright test runner. The number of workers used during Continuous Integration (CI) runs is increased from 1 to 2, which should improve test execution speed on CI environments.

- Increased the `workers` setting in `playwright.config.ts` for CI environments from 1 to 2, allowing tests to run in parallel and potentially reducing CI execution time.