### PR TITLE
fix: enhance affiliations field validation in edit dialog and schema

### DIFF
--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -479,7 +479,7 @@ test.describe("世界樹の暦ページのテスト", () => {
       test("冒険者を削除できること", async ({ page }) => {
         // Arrange
         await navigateToEtrianCalendar(page);
-        await page.getByTestId("toggle-edit-mode").click();
+        await page.getByRole("button", { name: "編集開始" }).click();
         await page.getByRole("button", { name: "削除: dummy" }).click();
 
         // Act

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -399,7 +399,26 @@ test.describe("世界樹の暦ページのテスト", () => {
       });
     });
 
-    test.describe.skip("作成時のテスト", () => {});
+    test.describe("作成時のテスト", () => {
+      test("冒険者を登録できること", async ({ page }) => {
+        // Arrange
+        await navigateToEtrianCalendar(page);
+        await page.getByRole("textbox", { name: "ししょー" }).fill("セトハ");
+
+        // Act
+        await page.getByRole("button", { name: "登録" }).click();
+
+        // Assert (表示が正しいこと)
+        await expect(toySection.getByText("セトハ")).toBeVisible();
+
+        // Assert (データストアへ登録されていること)
+        const migrated: EtrianRegistry = await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key)!),
+          ETRIAN_REGISTRY_STORAGE_KEY,
+        );
+        expect(migrated.etrians[0].name).toBe("セトハ");
+      });
+    });
 
     test.describe.skip("更新時のテスト", () => {});
 

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -475,7 +475,27 @@ test.describe("世界樹の暦ページのテスト", () => {
       });
     });
 
-    test.describe.skip("削除時のテスト", () => {});
+    test.describe("削除時のテスト", () => {
+      test("冒険者を削除できること", async ({ page }) => {
+        // Arrange
+        await navigateToEtrianCalendar(page);
+        await page.getByTestId("toggle-edit-mode").click();
+        await page.getByRole("button", { name: "削除: dummy" }).click();
+
+        // Act
+        await page.getByRole("button", { name: "削除" }).click();
+
+        // Assert (表示が正しいこと)
+        await expect(toySection.getByText("dummy").first()).not.toBeVisible();
+
+        // Assert (データストアへ登録されていないこと)
+        const migrated: EtrianRegistry = await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key)!),
+          ETRIAN_REGISTRY_STORAGE_KEY,
+        );
+        expect(migrated.etrians[0].name).not.toBe("dummy");
+      });
+    });
 
     test.describe("移行時のテスト", () => {
       test("EtrianV1 型が保存されている状態で、画面が初期表示された時、最新の型に揃えた初期値が設定されること (月なし -> 月あり)", async ({

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -598,42 +598,42 @@ test.describe("世界樹の暦ページのテスト", () => {
           page.getByText("登録内容の初期化が必要です"),
         ).toBeVisible();
       });
-    });
 
-    test("型定義に一致しない冒険者が保存されていて移行が行えないとき、登録内容がリセットされること", async ({
-      page,
-    }) => {
-      // Arrange
-      const etrians = [
-        {
-          id: "test-etrian",
-          name: "セトハ",
-          dateOfBirth_: {}, // 型定義に一致しない
-          affiliations: ["ブレイバント", "アルカディア"],
-          order: 0,
-          memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
-        },
-      ];
-      await page.evaluate(
-        ([key, value]) => {
-          localStorage.setItem(key, value);
-        },
-        [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
-      );
-      await navigateToEtrianCalendar(page);
+      test("型定義に一致しない冒険者が保存されていて移行が行えないとき、登録内容がリセットされること", async ({
+        page,
+      }) => {
+        // Arrange
+        const etrians = [
+          {
+            id: "test-etrian",
+            name: "セトハ",
+            dateOfBirth_: {}, // 型定義に一致しない
+            affiliations: ["ブレイバント", "アルカディア"],
+            order: 0,
+            memo: "突剣を自在に扱う冒険者。没落貴族の一人娘。",
+          },
+        ];
+        await page.evaluate(
+          ([key, value]) => {
+            localStorage.setItem(key, value);
+          },
+          [ETRIAN_REGISTRY_STORAGE_KEY, JSON.stringify(etrians)],
+        );
+        await navigateToEtrianCalendar(page);
 
-      // Act
-      await page.getByRole("button", { name: "リセットする" }).click();
+        // Act
+        await page.getByRole("button", { name: "リセットする" }).click();
 
-      // Assert (初期値が表示されること)
-      await expect(toySection.getByText("ししょー").first()).toBeVisible();
+        // Assert (初期値が表示されること)
+        await expect(toySection.getByText("ししょー").first()).toBeVisible();
 
-      // Assert (初期値が設定されること)
-      const migrated: EtrianRegistry = await page.evaluate(
-        (key) => JSON.parse(localStorage.getItem(key)!),
-        ETRIAN_REGISTRY_STORAGE_KEY,
-      );
-      expect(migrated.etrians[0].name).toBe("ししょー");
+        // Assert (初期値が設定されること)
+        const migrated: EtrianRegistry = await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key)!),
+          ETRIAN_REGISTRY_STORAGE_KEY,
+        );
+        expect(migrated.etrians[0].name).toBe("ししょー");
+      });
     });
   });
 });

--- a/e2e/app/(toys)/etrian-calendar/page.spec.ts
+++ b/e2e/app/(toys)/etrian-calendar/page.spec.ts
@@ -420,7 +420,60 @@ test.describe("世界樹の暦ページのテスト", () => {
       });
     });
 
-    test.describe.skip("更新時のテスト", () => {});
+    test.describe("更新時のテスト", () => {
+      test("冒険者を編集できること", async ({ page }) => {
+        // Arrange
+        await navigateToEtrianCalendar(page);
+        await page.getByRole("button", { name: "編集: dummy" }).click();
+        await page.getByRole("textbox", { name: "名前 *" }).fill("セトハ");
+        await page.getByRole("combobox", { name: "誕生月" }).click();
+        await page.getByRole("option", { name: "皇帝ノ月" }).click();
+        await page.getByRole("combobox", { name: "日" }).click();
+        await page.getByRole("option", { name: "1", exact: true }).click();
+        await page
+          .getByRole("textbox", { name: "所属" })
+          .fill("ブレイバント,アルカディア");
+        await page
+          .getByRole("textbox", { name: "メモ" })
+          .fill("突剣を自在に扱う冒険者。没落貴族の一人娘。");
+
+        // Act
+        await page.getByRole("button", { name: "更新" }).click();
+
+        // Assert (表示が正しいこと)
+        await expect(toySection.getByText("セトハ").first()).toBeVisible();
+        await expect(
+          toySection.getByText("皇帝ノ月 1 日").first(),
+        ).toBeVisible();
+        await expect(
+          toySection.getByText("ブレイバント").first(),
+        ).toBeVisible();
+        await expect(
+          toySection.getByText("アルカディア").first(),
+        ).toBeVisible();
+        await expect(
+          toySection
+            .getByText("突剣を自在に扱う冒険者。没落貴族の一人娘。")
+            .first(),
+        ).toBeVisible();
+
+        // Assert (データストアへ登録されていること)
+        const migrated: EtrianRegistry = await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key)!),
+          ETRIAN_REGISTRY_STORAGE_KEY,
+        );
+        expect(migrated.version).toBe(2);
+        expect(migrated.etrians[0].dateOfBirth).toEqual({
+          month: "皇帝ノ月",
+          day: 1,
+        });
+        expect(migrated.etrians[0].name).toBe("セトハ");
+        expect(migrated.etrians[0].affiliations).toEqual([
+          "ブレイバント",
+          "アルカディア",
+        ]);
+      });
+    });
 
     test.describe.skip("削除時のテスト", () => {});
 

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -250,19 +250,29 @@ export function EditDialog({
                 )}
               </Field>
 
-              <Field>
-                <FieldLabel htmlFor="etrian-affiliations">所属</FieldLabel>
-                <Input
-                  id="etrian-affiliations"
-                  placeholder="ギルド名,エトリア,etc..."
-                  autoComplete="off"
-                  {...form.register("affiliations")}
-                />
-                <FieldDescription>
-                  所属ギルドや居住地などを入力してください。
-                  <br />, で区切ると、複数の所属を登録できます。
-                </FieldDescription>
-              </Field>
+              <Controller
+                name="affiliations"
+                control={form.control}
+                render={({ field, fieldState }) => (
+                  <Field>
+                    <FieldLabel htmlFor="etrian-affiliations">所属</FieldLabel>
+                    <Input
+                      {...field}
+                      id="etrian-affiliations"
+                      placeholder="ギルド名,エトリア,etc..."
+                      autoComplete="off"
+                      {...form.register("affiliations")}
+                    />
+                    <FieldDescription>
+                      所属ギルドや居住地などを入力してください。
+                      <br />, で区切ると、複数の所属を登録できます。
+                    </FieldDescription>
+                    {fieldState.invalid && (
+                      <FieldError errors={[fieldState.error]} />
+                    )}
+                  </Field>
+                )}
+              />
 
               <Controller
                 name="memo"

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/dialog/edit-dialog.tsx
@@ -261,7 +261,6 @@ export function EditDialog({
                       id="etrian-affiliations"
                       placeholder="ギルド名,エトリア,etc..."
                       autoComplete="off"
-                      {...form.register("affiliations")}
                     />
                     <FieldDescription>
                       所属ギルドや居住地などを入力してください。

--- a/src/app/(toys)/etrian-calendar/_features/registry/components/etrian-registry-list.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/components/etrian-registry-list.tsx
@@ -118,6 +118,7 @@ function EtrianRegistryItem({
                 variant="destructive"
                 size="icon"
                 className="rounded-full"
+                aria-label={`削除: ${etrian.name}`}
               >
                 <Trash2 />
               </Button>
@@ -129,6 +130,7 @@ function EtrianRegistryItem({
                 className="rounded-full"
                 onClick={() => onReorder(index, index - 1)}
                 disabled={index === 0}
+                aria-label={`上へ移動: ${etrian.name}`}
               >
                 <ChevronUp />
               </Button>
@@ -139,6 +141,7 @@ function EtrianRegistryItem({
                 className="rounded-full"
                 onClick={() => onReorder(index, index + 1)}
                 disabled={index === length - 1}
+                aria-label={`下へ移動: ${etrian.name}`}
               >
                 <ChevronDown />
               </Button>
@@ -148,6 +151,7 @@ function EtrianRegistryItem({
                   variant="secondary"
                   size="icon"
                   className="rounded-full"
+                  aria-label={`編集: ${etrian.name}`}
                 >
                   <Pencil />
                 </Button>
@@ -158,7 +162,12 @@ function EtrianRegistryItem({
 
         {!isEditing && (
           <EditDialog etrian={etrian} onSave={onUpdate}>
-            <Button variant="secondary" size="icon" className="rounded-full">
+            <Button
+              variant="secondary"
+              size="icon"
+              className="rounded-full"
+              aria-label={`編集: ${etrian.name}`}
+            >
               <Pencil />
             </Button>
           </EditDialog>

--- a/src/app/(toys)/etrian-calendar/_features/registry/etrian-registry.tsx
+++ b/src/app/(toys)/etrian-calendar/_features/registry/etrian-registry.tsx
@@ -182,13 +182,17 @@ export function EtrianRegistry() {
                   onConfirm={handleReset}
                   className="w-fit"
                 >
-                  <Button variant="destructive">リセット</Button>
+                  <Button variant="destructive" aria-label="リセット">
+                    リセット
+                  </Button>
                 </ConfirmDialog>
                 <BackupDialog
                   storedEtrianRegistry={storedEtrianRegistry}
                   className="w-fit"
                 >
-                  <Button variant="secondary">バックアップ</Button>
+                  <Button variant="secondary" aria-label="バックアップ">
+                    バックアップ
+                  </Button>
                 </BackupDialog>
               </>
             )}
@@ -197,6 +201,7 @@ export function EtrianRegistry() {
           <Button
             variant={isEditing ? "default" : "secondary"}
             onClick={() => setIsEditing((prev) => !prev)}
+            aria-label={isEditing ? "編集完了" : "編集開始"}
           >
             <UserPen />
             {isEditing ? "完了" : "編集"}

--- a/src/app/(toys)/etrian-calendar/_features/registry/schemas/registry-form-schema.ts
+++ b/src/app/(toys)/etrian-calendar/_features/registry/schemas/registry-form-schema.ts
@@ -20,7 +20,10 @@ export const registryFormSchema = z
         day: z.enum([UNSET_SELECT_VALUE, ...etrianDayOptions]).optional(),
       })
       .optional(),
-    affiliations: z.string().optional(),
+    affiliations: z
+      .string()
+      .max(50, "50 文字以下で入力してください。")
+      .optional(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
This pull request enhances the 世界樹の暦 (Etrian Calendar) feature with improved accessibility, more robust testing, and better form validation. The main updates include adding comprehensive end-to-end tests for adventurer creation, editing, and deletion; introducing accessibility labels for interactive elements; and enforcing a character limit on the "affiliations" field in the registry form.

**Testing improvements:**

* Added end-to-end tests for adventurer creation, editing, and deletion, ensuring correct UI updates and data persistence in localStorage. These tests cover registering a new adventurer, editing details (including affiliations and memo), and deleting entries, with assertions on both UI and storage state. [[1]](diffhunk://#diff-c0cad73bcd1405ee383bd38323a66e21a62b5ed69987fe9e3cb00f4c1892749cL402-R498) [[2]](diffhunk://#diff-c0cad73bcd1405ee383bd38323a66e21a62b5ed69987fe9e3cb00f4c1892749cL601) [[3]](diffhunk://#diff-c0cad73bcd1405ee383bd38323a66e21a62b5ed69987fe9e3cb00f4c1892749cR731)

**Accessibility enhancements:**

* Added `aria-label` attributes to all relevant buttons in `EtrianRegistryItem` and `EtrianRegistry` components, including delete, edit, reorder, reset, and backup actions, improving accessibility for screen readers. [[1]](diffhunk://#diff-fbbd2ae960556a90ccdade2f1a4d1162cd050efe1216dd17944cf32eb0208e32R121) [[2]](diffhunk://#diff-fbbd2ae960556a90ccdade2f1a4d1162cd050efe1216dd17944cf32eb0208e32R133) [[3]](diffhunk://#diff-fbbd2ae960556a90ccdade2f1a4d1162cd050efe1216dd17944cf32eb0208e32R144) [[4]](diffhunk://#diff-fbbd2ae960556a90ccdade2f1a4d1162cd050efe1216dd17944cf32eb0208e32R154) [[5]](diffhunk://#diff-fbbd2ae960556a90ccdade2f1a4d1162cd050efe1216dd17944cf32eb0208e32L161-R170) [[6]](diffhunk://#diff-3e01c9d1b31b190d3f384d36dcde1c110880887928806cc68b667d74d2affb25L185-R195) [[7]](diffhunk://#diff-3e01c9d1b31b190d3f384d36dcde1c110880887928806cc68b667d74d2affb25R204)

**Form validation and UI feedback:**

* Enforced a maximum length of 50 characters for the "affiliations" field in the registry form schema, and updated the edit dialog to display field errors if validation fails. [[1]](diffhunk://#diff-5de2cc6c4fc7e056abefde1e2ab1bfeca2d42be6016ce707216d565e7b057061L23-R26) [[2]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093R253-R260) [[3]](diffhunk://#diff-acdafaa2d847aca559619e7ae5268e66a7964044ab9399d18641c236088f6093R270-R275)